### PR TITLE
Add service control parameters to main class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,8 @@ class bitcoind (
   $upnp                       = true,
   $user_name                  = 'bitcoind',
   $user_home                  = '/home/bitcoind',
+  $service_ensure             = running,
+  $service_enable             = true,
 ){
 
   # Hard-fail on anything that isn't Ubuntu


### PR DESCRIPTION
The bitcoind::service class responds internally to two parameters -
bitcoind_ensure and bitcoind_enable - which were not declared. By adding these
parameters with defaults running and true, respectively, the module will
actually start and refresh the daemon, and cause it to start at boot.
